### PR TITLE
Allow TZ to effect timestamps of logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY start.sh /start.sh
 # Install any needed packages
 
 RUN apk update \
-  && apk add --no-cache python3 py-netifaces git \
+  && apk add --no-cache python3 py-netifaces git tzdata \
   && git clone --depth 1 https://github.com/alsmith/multicast-relay.git \
   && apk del git 
 # use b fixBroadcast option before URL to download specific sub branch


### PR DESCRIPTION
The docker image is missing the tzdata package. This results in setting 
TZ in a local deployment to be ignored. Logs currently all come out in 
UTC. This is a small fix to allow TZ to be honored.

Thanks for the project! This has been helpful in my own segmented 
Sonos & Unifi deployment! :)
