### PR TITLE
Draft-then-publish releases for immutable-releases repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -483,12 +483,27 @@ jobs:
           } > release-notes.md
           cat release-notes.md
 
-      - name: Publish release
+      # Created as a draft, then published by a separate PATCH. A published
+      # release is frozen on an immutable-releases repo, so anything that
+      # creates-then-modifies fails; drafting first keeps every write before
+      # the freeze. Same approach as the sysext repos.
+      - name: Create draft release
+        id: release
         uses: softprops/action-gh-release@v3
         with:
           name: ${{ github.ref_name }}
           body_path: release-notes.md
           generate_release_notes: true
-          make_latest: 'true'
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish the draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REL_ID: ${{ steps.release.outputs.id }}
+        run: |
+          gh api --method PATCH "repos/${REPO}/releases/${REL_ID}" \
+            -F draft=false -f make_latest=true
+          echo "Published release ${REL_ID}"


### PR DESCRIPTION
Immutable releases are now enabled on this repo. A published release is frozen, so anything that creates-then-modifies a release fails.

Mirrors the pattern already used in the sysext repos (`# Draft first so assets attach even on immutable-release repos.`): create the release as a draft so every write happens before the freeze, then publish it with a single PATCH that also marks it latest.

Needed before cutting v1.0.0, which is the first release this path will ever run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)